### PR TITLE
Get kolibri-daemon bus name from kolibri_app

### DIFF
--- a/kolibri_desktop_auth_plugin/backends.py
+++ b/kolibri_desktop_auth_plugin/backends.py
@@ -3,9 +3,16 @@ from gi.repository import Gio
 from .models import DesktopUser
 
 
-DBUS_ID = "org.learningequality.Kolibri.Daemon"
-DBUS_PATH = "/" + DBUS_ID.replace(".", "/") + "/Private"
-IFACE = DBUS_ID + ".Private"
+try:
+    import kolibri_app.config
+except ImportError:
+    DBUS_ID = "org.learningequality.Kolibri.Daemon"
+    DBUS_PATH = "/" + DBUS_ID.replace(".", "/") + "/Private"
+else:
+    DBUS_ID = kolibri_app.config.DAEMON_APPLICATION_ID
+    DBUS_PATH = kolibri_app.config.DAEMON_PRIVATE_OBJECT_PATH
+
+IFACE = "org.learningequality.Kolibri.Daemon.Private"
 
 
 class TokenAuthBackend:


### PR DESCRIPTION
With this change, the plugin works in the Devel version of the Kolibri flatpak.

https://phabricator.endlessm.com/T32614