### PR TITLE
Check if the device is provisioned

### DIFF
--- a/kolibri_desktop_auth_plugin/views.py
+++ b/kolibri_desktop_auth_plugin/views.py
@@ -2,19 +2,17 @@ from django.contrib.auth import authenticate
 from django.contrib.auth import login
 from django.shortcuts import redirect
 from django.views import View
+from kolibri.core.device.utils import device_provisioned
 from kolibri.dist.django.core.urlresolvers import reverse
 
 
 class LoginView(View):
     def get(self, request, token):
-        user = authenticate(token=token)
-        if not user:
-            return redirect(reverse("kolibri:core:redirect_user"))
+        if device_provisioned():
+            user = authenticate(token=token)
+            if not user:
+                return redirect(reverse("kolibri:core:redirect_user"))
+            login(request, user)
 
-        login(request, user)
-
-        next_url = request.GET.get("next")
-        if next_url:
-            return redirect(next_url)
-
-        return redirect("/")
+        next_url = request.GET.get("next", "/")
+        return redirect(next_url)


### PR DESCRIPTION
Otherwise a validation error happens when trying to create the user:
"FacilityUser has no facility".

Also, simplify the next URL by passing a default value to request.GET
dict.

https://phabricator.endlessm.com/T32613