### PR TITLE
Synchronize the interface name from the DBus' bus name automatically

### DIFF
--- a/kolibri_desktop_auth_plugin/backends.py
+++ b/kolibri_desktop_auth_plugin/backends.py
@@ -12,7 +12,7 @@ else:
     DBUS_ID = kolibri_app.config.DAEMON_APPLICATION_ID
     DBUS_PATH = kolibri_app.config.DAEMON_PRIVATE_OBJECT_PATH
 
-IFACE = "org.learningequality.Kolibri.Daemon.Private"
+IFACE = DBUS_ID + ".Private"
 
 
 class TokenAuthBackend:


### PR DESCRIPTION
The original interface name is hard coded. It should be synchronized with the bus name automatically.