### PR TITLE
Revert "Synchronize the interface name from the DBus' bus name automatically"

### DIFF
--- a/kolibri_desktop_auth_plugin/backends.py
+++ b/kolibri_desktop_auth_plugin/backends.py
@@ -12,7 +12,7 @@ else:
     DBUS_ID = kolibri_app.config.DAEMON_APPLICATION_ID
     DBUS_PATH = kolibri_app.config.DAEMON_PRIVATE_OBJECT_PATH
 
-IFACE = DBUS_ID + ".Private"
+IFACE = "org.learningequality.Kolibri.Daemon.Private"
 
 
 class TokenAuthBackend:


### PR DESCRIPTION
This reverts commit 6e45e370a3ab8c9815828d7a499f5d82f7747225.

More detail discussion in "Do not change the D-Bus interface name" [1] and "Synchronize the interface name from the DBus' bus name automatically" [2].

[1]: https://github.com/endlessm/endless-key-flatpak/pull/14
[2]: https://github.com/endlessm/kolibri-desktop-auth-plugin/pull/12